### PR TITLE
Add time-based redirect to closet device

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # teste
-Criar um repositorio publico
+
+Este repositório inclui um exemplo de configuração do ESPHome para um Sonoff Mini. O arquivo `sonoff_mini.yaml` contém as diretivas necessárias para compilar e instalar o firmware no dispositivo.
+
+O exemplo também mostra como usar condicionais de tempo para redirecionar o comando do botão. Se o dispositivo for acionado entre meia-noite e seis da manhã, ele não liga o próprio relê e sim o Sonoff denominado "closet" por meio de uma chamada de serviço ao Home Assistant.

--- a/sonoff_mini.yaml
+++ b/sonoff_mini.yaml
@@ -1,0 +1,80 @@
+esphome:
+  name: sonoff_mini
+  platform: ESP8266
+  board: esp8285
+
+wifi:
+  ssid: "<YOUR_WIFI_SSID>"
+  password: "<YOUR_WIFI_PASSWORD>"
+
+  ap:
+    ssid: "Sonoff Mini"
+    password: "<AP_PASSWORD>"
+
+captive_portal:
+
+logger:
+
+api:
+  password: "<API_PASSWORD>"
+
+ota:
+  password: "<OTA_PASSWORD>"
+
+time:
+  - platform: homeassistant
+    id: esptime
+
+switch:
+  - platform: gpio
+    name: "Sonoff Mini Relay"
+    pin: GPIO12
+    id: relay
+    restore_mode: RESTORE_DEFAULT_OFF
+
+binary_sensor:
+  - platform: gpio
+    name: "Sonoff Mini Button"
+    pin:
+      number: GPIO0
+      mode: INPUT_PULLUP
+      inverted: true
+    on_press:
+      - if:
+          condition:
+            lambda: |-
+              auto t = id(esptime).now();
+              if (!t.is_valid()) return false;
+              return t.hour < 6;
+          then:
+            - homeassistant.service:
+                service: switch.toggle
+                data:
+                  entity_id: switch.closet
+          else:
+            - switch.toggle: relay
+  - platform: gpio
+    name: "External Switch"
+    pin:
+      number: GPIO4
+      mode: INPUT_PULLUP
+      inverted: true
+    on_press:
+      - if:
+          condition:
+            lambda: |-
+              auto t = id(esptime).now();
+              if (!t.is_valid()) return false;
+              return t.hour < 6;
+          then:
+            - homeassistant.service:
+                service: switch.toggle
+                data:
+                  entity_id: switch.closet
+          else:
+            - switch.toggle: relay
+
+status_led:
+  pin:
+    number: GPIO13
+    inverted: true


### PR DESCRIPTION
## Summary
- update README to mention time-based redirect to closet
- add Home Assistant time component
- reroute button/switch presses to `switch.closet` from midnight to 6 AM

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6879c4f35ebc833090d4ace4a76101d2